### PR TITLE
plist-sort: fix empty PLIST_SUB substitutions

### DIFF
--- a/plist-sort
+++ b/plist-sort
@@ -40,7 +40,7 @@ BEGIN {
 		if (p_array[1] in opt_subs)
 			continue;
 		gsub("\"", "", p_array[2]);
-		if (p_array[2] && p_array[2] != "@comment")
+		if (p_array[2] != "@comment")
 			subs[p_array[1]] = p_array[2];
 	}
 }
@@ -122,8 +122,12 @@ function keyword_line_untokenize(line, keyword) {
 		}
 		if (cmd == "")
 			cmd = "%%" p[i] "%%";
-		else if (p[i] in subs)
-			path = str_replace(path, subs[p[i]], "%%" p[i] "%%");
+		else if (p[i] in subs) {
+			if (subs[p[i]] == "")
+				path = "%%" p[i] "%%" path;
+			else
+				path = str_replace(path, subs[p[i]], "%%" p[i] "%%");
+		}
 	}
 	if (keyword == "dir")
 		sub(/zzz$/, "", path);
@@ -163,7 +167,10 @@ function print_files(array, file) {
 				continue;
 			}
 			if (p[i] in subs) {
-				path = str_replace(path, subs[p[i]], "%%" p[i] "%%");
+				if (subs[p[i]] == "")
+					path = "%%" p[i] "%%" path;
+				else
+					path = str_replace(path, subs[p[i]], "%%" p[i] "%%");
 				continue;
 			}
 			path = p[i] path;


### PR DESCRIPTION
Fix handling of empty PLIST_SUB variables.

Variables defined as empty were incorrectly collapsed from "%%VAR%%" to "VAR".